### PR TITLE
Fix POD

### DIFF
--- a/Fq.pm
+++ b/Fq.pm
@@ -72,7 +72,11 @@ C<$channel> is the routing key used for the Fq message.
 
 C<$message> is the message payload (binary is allowed).
 
+=back
+
 =head2 Static Functions
+
+=over 4
 
 =item Logger::Fq::backlog()
 
@@ -93,6 +97,8 @@ is specified, print to STDERR the number of messages drain and the time waited.
 =item Logger::Fq::debug($flags)
 
 Sets the fileno=2 debugging bits for libfq.
+
+=back
 
 =cut
 


### PR DESCRIPTION
I got following error when I see POD of this package.

```
POD ERRORS
    Hey! The above document had some coding errors, which are explained
    below:

    Around line 75:
        You forgot a '=back' before '=head2'

    Around line 77:
        '=item' outside of any '=over'

        =over without closing =back
```
